### PR TITLE
Add typed env config module with example env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+NEXT_PUBLIC_SITE_NAME=Webspind
+NEXT_PUBLIC_TIMEZONE=Europe/Copenhagen
+NEXT_PUBLIC_PAYMENTS_ENABLED=false
+JWT_SECRET=dev-only-secret-change-me
+DATABASE_URL=postgres://user:pass@localhost:5432/webspind

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Dependencies
+node_modules/
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# System files
+.DS_Store

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,27 @@
+export interface AppConfig {
+  siteName: string;
+  timezone: string;
+  paymentsEnabled: boolean;
+  jwtSecret?: string;
+  tokensEnabled: boolean;
+  databaseUrl: string;
+}
+
+const jwtSecret = process.env.JWT_SECRET;
+
+if (!jwtSecret && process.env.NODE_ENV !== 'production') {
+  console.warn(
+    'JWT_SECRET is not set. Token creation will be disabled.'
+  );
+}
+
+export const config: AppConfig = {
+  siteName: process.env.NEXT_PUBLIC_SITE_NAME ?? 'Webspind',
+  timezone: process.env.NEXT_PUBLIC_TIMEZONE ?? 'Europe/Copenhagen',
+  paymentsEnabled:
+    process.env.NEXT_PUBLIC_PAYMENTS_ENABLED === 'true',
+  jwtSecret,
+  tokensEnabled: Boolean(jwtSecret),
+  databaseUrl:
+    process.env.DATABASE_URL ?? 'postgres://user:pass@localhost:5432/webspind',
+};


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholder configuration keys
- create typed env config module handling defaults and JWT warnings
- ignore local env files and system artifacts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c062042fe883308dec77041b9ea802